### PR TITLE
X-Forwarded-Proto for non-ssl horizon application

### DIFF
--- a/horizon/files/openstack-dashboard.conf.Debian
+++ b/horizon/files/openstack-dashboard.conf.Debian
@@ -29,6 +29,9 @@
   LogFormat "{{ server.apache_log_format }}" horizon
   ErrorLog "{{ server.apache_log_dir }}/{{ server.apache_log_filename }}_error.log"
   CustomLog "{{ server.apache_log_dir }}/{{ server.apache_log_filename }}_access.log" horizon
+  {%- if pillar.get('nginx', {}).get('server', {}).get('site', {}).get('nginx_proxy_openstack_web', {}).get('ssl', {}).get('enabled', False) %}
+  SetEnvIf X-Forwarded-Proto https HTTPS=1
+  {%- endif %}
 
 </VirtualHost>
 


### PR DESCRIPTION
Running horizon under load balancer with SSL, we should set X-Forwarded-Proto to https instead of http for horizon application.