### PR TITLE
Fixes for Murano Dashboard

### DIFF
--- a/horizon/files/horizon_settings/_local_settings.py
+++ b/horizon/files/horizon_settings/_local_settings.py
@@ -122,7 +122,8 @@ AUTHENTICATION_BACKENDS = ('csb_auth.backend.CSBackend',)
 {%- endif %}
 
 {%- if app.murano_api is defined %}
-MURANO_API_URL = "http://{{ app.murano_api.host }}:{{ app.murano_api.port }}"
+MURANO_API_URL = "{{ app.murano_api.get('protocol', 'http') }}://{{ app.murano_api.host }}:{{ app.murano_api.port }}"
+MURANO_API_INSECURE = "{{ app.murano_api.get('insecure', 'False') }}"
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 # TODO(majklk) make this configurable
 MURANO_REPO_URL = 'http://storage.apps.openstack.org/'


### PR DESCRIPTION
  * Add possibility to specify protocol for Murano Dashboard
    If we are running Murano under SSL on load-balancer or
    nginx we will get the following error:

    `Error: 400 The plain HTTP request was sent to HTTPS port: 400 Bad`
    `Request: The plain HTTP request was sent to HTTPS port: nginx`

    To avoid this we need to switch from hardcoded http to https.

  * If we are going to use self-signed certificates we should set
    MURANO_API_INSECURE = True
    https://docs.openstack.org/developer/murano/administrator-guide/deploy_murano/configure_ssl.html#configure-ssl-for-the-dashboard