### PR TITLE
Add parameter for specific env indication

### DIFF
--- a/horizon/files/horizon_settings/_local_settings.py
+++ b/horizon/files/horizon_settings/_local_settings.py
@@ -204,4 +204,7 @@ RAVEN_CONFIG = {
 {%- endif %}
 
 SITE_BRANDING = '{{ app.get('branding', 'OpenStack Dashboard') }}'
+{%- if app.site_details is defined %}
+SITE_DETAILS = "{{ app.site_details }}"
+{%- endif %}
 SESSION_COOKIE_HTTPONLY = {{ app.get('session_cookie_httponly', True) }}


### PR DESCRIPTION
Add 'SITE_DETAILS' parameter to local_settings.py
that allows to indicate specific environment.
Should contain a string, that will be shown on login
and main pages.