### PR TITLE
Revert "Set correct SESSION_ENGINE for memcached cache.engine"

### DIFF
--- a/horizon/files/horizon_settings/_local_settings.py
+++ b/horizon/files/horizon_settings/_local_settings.py
@@ -26,10 +26,6 @@ LOCAL_PATH = os.path.dirname(os.path.abspath(__file__))
 
 SECRET_KEY = '{{ app.secret_key }}'
 
-{% if app.cache.get('engine', 'signed_cookies') == 'memcached' %}
-SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
-{% endif %}
-
 CACHES = {
     'default': {
 


### PR DESCRIPTION
Reverts salt-formulas/salt-formula-horizon#13

Accidentally merged. If condition tests incorrect pillar key (cache) for SESSION_BACKEND config key value