### PR TITLE
Session related parameters and horizon cluster pillar refresh

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,18 @@ Horizon package setup with SSL
         mail:
           host: '127.0.0.1'
 
+Horizon with custom SESSION_ENGINE (default is "signed_cookies", valid options are: "signed_cookies", "cache", "file") and SESSION_TIMEOUT
+
+.. code-block:: yaml
+
+    horizon:
+      server:
+        enabled: True
+        secure: True
+        session:
+          engine: 'cache'
+          timeout: 43200
+
 Multi-regional horizon setup
 
 .. code-block:: yaml

--- a/horizon/files/horizon_settings/_horizon_settings.py
+++ b/horizon/files/horizon_settings/_horizon_settings.py
@@ -20,9 +20,8 @@
 # OpenStack services are using to determine role based access control in the
 # target installation.
 
-{%- if server.session_timeout is defined %}
-SESSION_TIMEOUT = {{ server.session_timeout }}
-{%- endif %}
+SESSION_TIMEOUT = {{ server.get('session', {}).get('timeout', 3600) }}
+SESSION_ENGINE = "django.contrib.sessions.backends.{{ server.get('session', {}).get('engine', 'signed_cookies') }}"
 
 # Path to directory containing policy.json files
 #POLICY_FILES_PATH = os.path.join(ROOT_PATH, "conf")

--- a/metadata/service/server/cluster.yml
+++ b/metadata/service/server/cluster.yml
@@ -4,21 +4,27 @@ classes:
 - service.horizon.support
 parameters:
   _param:
-    horizon_version: kilo
+    horizon_version: liberty
+    horizon_identity_host: localhost
     horizon_identity_version: 3
+    horizon_identity_encryption: none
     horizon_identity_endpoint_type: internalURL
   horizon:
     server:
       enabled: true
       version: ${_param:horizon_version}
       secret_key: ${_param:horizon_secret_key}
-      session_timeout: 43200
-      wsgi:
-        processes: 3
-        threads: 10
+      session:
+        timeout: 43200
+        engine: 'signed_cookies'
       bind:
         address: ${_param:cluster_local_address}
         port: 80
+      wsgi:
+        processes: 3
+        threads: 10
+      mail:
+        identity: ${_param:horizon_identity_version}
       cache:
         engine: memcached
         prefix: 'CACHE_HORIZON'
@@ -29,31 +35,9 @@ parameters:
           port: 11211
         - host: ${_param:cluster_node03_address}
           port: 11211
-      api_versions:
-        identity: ${_param:horizon_identity_version}
       identity:
         engine: keystone
-        host: ${_param:cluster_vip_address}
         port: 5000
+        host: ${_param:horizon_identity_host}
+        encryption: ${_param:horizon_identity_encryption}
         endpoint_type: ${_param:horizon_identity_endpoint_type}
-  haproxy:
-    proxy:
-      listens:
-      - name: horizon
-        type: horizon
-        binds:
-        - address: ${_param:cluster_vip_address}
-          port: 80
-        servers:
-        - name: ctl01
-          host: ${_param:cluster_node01_address}
-          port: 80
-          params: cookie ctl01 check inter 2000 fall 3
-        - name: ctl02
-          host: ${_param:cluster_node02_address}
-          port: 80
-          params: cookie ctl02 check inter 2000 fall 3
-        - name: ctl03
-          host: ${_param:cluster_node03_address}
-          port: 80
-          params: cookie ctl03 check inter 2000 fall 3

--- a/metadata/service/server/single.yml
+++ b/metadata/service/server/single.yml
@@ -14,7 +14,9 @@ parameters:
       enabled: true
       version: ${_param:horizon_version}
       secret_key: ${_param:horizon_secret_key}
-      session_timeout: 43200
+      session:
+        timeout: 43200
+        engine: 'signed_cookies'
       bind:
         address: ${_param:single_address}
         port: 80


### PR DESCRIPTION
SESSION_ENGINE parameter introduced, pillar for SESSION_TIMEOUT changed. Actualized pillar for horizon.server.cluster service